### PR TITLE
Add explanatory comments to scoring logic for 10,000 dice game

### DIFF
--- a/game.py
+++ b/game.py
@@ -85,25 +85,30 @@ class Game:
         dice: list[int],
     ) -> int:
         """Returns the score for a given dice roll, following 10,000 rules."""
+        # Counts the number of each die in the roll and groups them by their value so we can check for sets and singles
         counts = Counter(dice)
         score = 0
 
-        # Straight (1-6)
+        # Simple check for a straight (1,2,3,4,5,6) → automatic 1000 points
         if sorted(counts.keys()) == [1, 2, 3, 4, 5, 6]:
             return 1000
 
-        # Three pairs (e.g. 2,2,3,3,6,6)
+        
+        # Check for three pairs (e.g. 2,2,3,3,6,6) by checking the length of the counts dictionary is 3 and all the values are 2  → automatic 1000 points  
         if len(counts) == 3 and all(v == 2 for v in counts.values()):
             return 1000
 
-        # Three-of-a-kind and above (scales exponentially)
+        # Three-of-a-kind and above (scales exponentially) by using a for loop to iterate through the counts dictionary and checking if the count is greater than or equal to 3
         for num, cnt in counts.items():
             if cnt >= 3:
+                # Base score = 1000 for triple 1's, else num * 100 for other triples 
                 base = 1000 if num == 1 else num * 100
-                score += base * (2 ** (cnt - 3))  # doubles per extra die
+                # Each extra die beyond three doubles the base score by using the exponentiation operator **
+                score += base * (2 ** (cnt - 3))
+                # Remove these dice from counts so we don't double-count singles by subtracting the count from the number of dice
                 counts[num] -= cnt
 
-        # Singles of 1's and 5's after removing sets
+        # Score remaining single 1's (100 each) and single 5's (50 each)
         score += counts[1] * 100
         score += counts[5] * 50
 


### PR DESCRIPTION
This PR improves the clarity of the scoring engine by adding detailed
comments explaining:

- How straights and three-pair scoring are detected
- How three-of-a-kind and higher sets are calculated
- Why 1's and 5's are treated differently
- How extra dice double the score for larger sets

No functional changes have been made — this is purely documentation to make
the code easier to understand and maintain.
